### PR TITLE
Update refresh logic. Remove erc20refresh

### DIFF
--- a/HSEthereumKit.podspec
+++ b/HSEthereumKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'HSEthereumKit'
-  spec.version = '0.3.1'
+  spec.version = '0.4.1'
   spec.summary = 'Ethereum wallet library for Swift'
   spec.description = <<-DESC
                        HSEthereumKit implements Ethereum protocol in Swift. Uses EthereumKit library.

--- a/HSEthereumKit.podspec
+++ b/HSEthereumKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'HSEthereumKit'
-  spec.version = '0.4.1'
+  spec.version = '0.4.0'
   spec.summary = 'Ethereum wallet library for Swift'
   spec.description = <<-DESC
                        HSEthereumKit implements Ethereum protocol in Swift. Uses EthereumKit library.

--- a/HSEthereumKit/HSEthereumKit/EthereumKit/Networking/Geth.swift
+++ b/HSEthereumKit/HSEthereumKit/EthereumKit/Networking/Geth.swift
@@ -116,7 +116,7 @@ public final class Geth {
     ///   - startBlock: which block to start.
     ///   - endBlock: which block to end
     ///   - completionHandler:
-    public func getTransactions(address: String, sort: Etherscan.GetTransactions.Sort = .des, startBlock: Int64 = 0, endBlock: Int64 = 99999999, completionHandler: @escaping (Result<Transactions>) -> Void) {
+    public func getTransactions(address: String, sort: Etherscan.GetTransactions.Sort = .asc, startBlock: Int64 = 0, endBlock: Int64 = 99999999, completionHandler: @escaping (Result<Transactions>) -> Void) {
         let request = Etherscan.GetTransactions(
             configuration: .init(baseURL: configuration.etherscanURL, apiKey: configuration.etherscanAPIKey),
             address: address,
@@ -127,7 +127,7 @@ public final class Geth {
         httpClient.send(request, completionHandler: completionHandler)
     }
 
-    public func getTokenTransactions(address: String, sort: Etherscan.GetTokenTransactions.Sort = .des, startBlock: Int64 = 0, endBlock: Int64 = 99999999, completionHandler: @escaping (Result<Transactions>) -> Void) {
+    public func getTokenTransactions(address: String, sort: Etherscan.GetTokenTransactions.Sort = .asc, startBlock: Int64 = 0, endBlock: Int64 = 99999999, completionHandler: @escaping (Result<Transactions>) -> Void) {
         let request = Etherscan.GetTokenTransactions(
             configuration: .init(baseURL: configuration.etherscanURL, apiKey: configuration.etherscanAPIKey),
             address: address,

--- a/HSEthereumKitDemo/HSEthereumKitDemo/BalanceController.xib
+++ b/HSEthereumKitDemo/HSEthereumKitDemo/BalanceController.xib
@@ -14,6 +14,7 @@
                 <outlet property="balanceCoinLabel" destination="4R3-0M-qsf" id="86N-nc-hM3"/>
                 <outlet property="balanceLabel" destination="lGE-w6-tlj" id="bQu-Wh-hoe"/>
                 <outlet property="lastBlockLabel" destination="OO3-Pv-oyv" id="1kW-Bw-heh"/>
+                <outlet property="progressCoinLabel" destination="0Go-7Y-hrB" id="uqu-tC-cDW"/>
                 <outlet property="progressLabel" destination="gaY-fU-Lj3" id="ayH-Ak-djH"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
@@ -54,20 +55,29 @@
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sync Coin Progress: n/a" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Go-7Y-hrB">
+                    <rect key="frame" x="20" y="203.5" width="335" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="oEu-Qf-bsR" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="23R-yJ-Nda"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="OO3-Pv-oyv" secondAttribute="trailing" constant="20" id="7OS-bT-DYR"/>
                 <constraint firstItem="OO3-Pv-oyv" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="95u-3L-BgN"/>
+                <constraint firstItem="0Go-7Y-hrB" firstAttribute="trailing" secondItem="4R3-0M-qsf" secondAttribute="trailing" id="AfO-VK-qZw"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="oEu-Qf-bsR" secondAttribute="bottom" constant="50" id="BYn-Fw-3hH"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="gaY-fU-Lj3" secondAttribute="trailing" constant="20" id="CCT-UW-a4d"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="lGE-w6-tlj" secondAttribute="trailing" constant="20" id="EVU-Gq-EMP"/>
+                <constraint firstItem="0Go-7Y-hrB" firstAttribute="leading" secondItem="4R3-0M-qsf" secondAttribute="leading" id="N11-TM-4Wf"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="4R3-0M-qsf" secondAttribute="trailing" constant="20" id="NTG-42-RFI"/>
                 <constraint firstItem="lGE-w6-tlj" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="PcQ-mW-IK0"/>
                 <constraint firstItem="OO3-Pv-oyv" firstAttribute="top" secondItem="gaY-fU-Lj3" secondAttribute="bottom" constant="20" id="RLe-xO-UBJ"/>
                 <constraint firstItem="lGE-w6-tlj" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="20" id="TyD-CB-sWZ"/>
                 <constraint firstItem="4R3-0M-qsf" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="bA1-0v-Kgl"/>
+                <constraint firstItem="0Go-7Y-hrB" firstAttribute="top" secondItem="4R3-0M-qsf" secondAttribute="bottom" constant="20" id="kul-BN-LH7"/>
                 <constraint firstItem="gaY-fU-Lj3" firstAttribute="top" secondItem="lGE-w6-tlj" secondAttribute="bottom" constant="20" id="uJl-lF-fNi"/>
                 <constraint firstItem="4R3-0M-qsf" firstAttribute="top" secondItem="OO3-Pv-oyv" secondAttribute="bottom" constant="20" id="voD-dp-SA5"/>
                 <constraint firstItem="gaY-fU-Lj3" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="wwD-hF-BEv"/>


### PR DESCRIPTION
- Use syncing status for ignore double refreshing
- Fail on of base response(block height, gas price or eth balance) must fail all states
- Fail on eth transactions request put notSynced for eth only
- Fail on erc20 token transaction request put notSynced for all erc20 tokens and fail get balances
- erc20 token balance requests set synced status for each
- transactions from etherscan get with asc mode to handle all txs by refreshing if its more 10000
- add synced status for balance controller

closes #35 