### PR TITLE
Refactor transaction syncers in order to avoid concurrent sync issues

### DIFF
--- a/Erc20Kit/Classes/Core/Erc20TransactionSyncer.swift
+++ b/Erc20Kit/Classes/Core/Erc20TransactionSyncer.swift
@@ -19,6 +19,7 @@ class Erc20TransactionSyncer {
         let events = transactions.map { tx in
             Event(
                     hash: tx.hash,
+                    blockNumber: tx.blockNumber,
                     contractAddress: tx.contractAddress,
                     from: tx.from,
                     to: tx.to,
@@ -36,8 +37,10 @@ class Erc20TransactionSyncer {
 
 extension Erc20TransactionSyncer: ITransactionSyncer {
 
-    public func transactionsSingle(lastBlockNumber: Int) -> Single<[Transaction]> {
-        provider.tokenTransactionsSingle(startBlock: lastBlockNumber + 1)
+    public func transactionsSingle() -> Single<[Transaction]> {
+        let lastBlockNumber = evmKit.lastEvent()?.blockNumber ?? 0
+
+        return provider.tokenTransactionsSingle(startBlock: lastBlockNumber + 1)
                 .do(onSuccess: { [weak self] transactions in
                     self?.handle(transactions: transactions)
                 })

--- a/EthereumKit/Classes/Core/Kit.swift
+++ b/EthereumKit/Classes/Core/Kit.swift
@@ -254,6 +254,10 @@ extension Kit {
         eip20Storage.save(balance: balance, contractAddress: contractAddress)
     }
 
+    public func lastEvent() -> Event? {
+        eip20Storage.lastEvent()
+    }
+
     public func events() -> [Event] {
         eip20Storage.events()
     }
@@ -334,8 +338,9 @@ extension Kit {
         let blockchain = RpcBlockchain.instance(address: address, storage: storage, syncer: syncer, transactionBuilder: transactionBuilder, logger: logger)
 
         let transactionStorage: ITransactionStorage = TransactionStorage(databaseDirectoryUrl: try dataDirectoryUrl(), databaseFileName: "transactions-\(uniqueId)")
+        let transactionSyncerStateStorage = TransactionSyncerStateStorage(databaseDirectoryUrl: try dataDirectoryUrl(), databaseFileName: "transaction-syncer-states-\(uniqueId)")
 
-        let ethereumTransactionSyncer = EthereumTransactionSyncer(provider: transactionProvider)
+        let ethereumTransactionSyncer = EthereumTransactionSyncer(provider: transactionProvider, storage: transactionSyncerStateStorage)
         let internalTransactionSyncer = InternalTransactionSyncer(provider: transactionProvider, storage: transactionStorage)
         let decorationManager = DecorationManager(userAddress: address, storage: transactionStorage)
         let transactionManager = TransactionManager(storage: transactionStorage, decorationManager: decorationManager, blockchain: blockchain, transactionProvider: transactionProvider)

--- a/EthereumKit/Classes/Core/Protocols.swift
+++ b/EthereumKit/Classes/Core/Protocols.swift
@@ -33,7 +33,6 @@ protocol IBlockchainDelegate: AnyObject {
 }
 
 protocol ITransactionStorage {
-    func lastTransaction() -> Transaction?
     func transaction(hash: Data) -> Transaction?
     func transactions(hashes: [Data]) -> [Transaction]
     func transactionsBefore(tags: [[String]], hash: Data?, limit: Int?) -> [Transaction]
@@ -43,6 +42,7 @@ protocol ITransactionStorage {
     func pendingTransactions(tags: [[String]]) -> [Transaction]
     func nonPendingTransactions(nonces: [Int]) -> [Transaction]
 
+    func lastInternalTransaction() -> InternalTransaction?
     func internalTransactions() -> [InternalTransaction]
     func internalTransactions(hashes: [Data]) -> [InternalTransaction]
     func save(internalTransactions: [InternalTransaction])
@@ -51,7 +51,7 @@ protocol ITransactionStorage {
 }
 
 public protocol ITransactionSyncer {
-    func transactionsSingle(lastBlockNumber: Int) -> Single<[Transaction]>
+    func transactionsSingle() -> Single<[Transaction]>
 }
 
 protocol ITransactionManagerDelegate: AnyObject {

--- a/EthereumKit/Classes/Core/TransactionManager.swift
+++ b/EthereumKit/Classes/Core/TransactionManager.swift
@@ -132,10 +132,6 @@ extension TransactionManager {
         storage.transaction(hash: hash).flatMap { decorationManager.decorate(transactions: [$0]).first }
     }
 
-    func lastTransaction() -> Transaction? {
-        storage.lastTransaction()
-    }
-
     @discardableResult func handle(transactions: [Transaction]) -> [FullTransaction] {
         guard !transactions.isEmpty else {
             return []

--- a/EthereumKit/Classes/Core/TransactionSyncerStateStorage.swift
+++ b/EthereumKit/Classes/Core/TransactionSyncerStateStorage.swift
@@ -1,0 +1,46 @@
+import RxSwift
+import GRDB
+
+class TransactionSyncerStateStorage {
+    private let dbPool: DatabasePool
+
+    init(databaseDirectoryUrl: URL, databaseFileName: String) {
+        let databaseURL = databaseDirectoryUrl.appendingPathComponent("\(databaseFileName).sqlite")
+
+        dbPool = try! DatabasePool(path: databaseURL.path)
+
+        try! migrator.migrate(dbPool)
+    }
+
+    var migrator: DatabaseMigrator {
+        var migrator = DatabaseMigrator()
+
+        migrator.registerMigration("create TransactionSyncerState") { db in
+            try db.create(table: TransactionSyncerState.databaseTableName) { t in
+                t.column(TransactionSyncerState.Columns.syncerId.name, .text).notNull().indexed()
+                t.column(TransactionSyncerState.Columns.lastBlockNumber.name, .integer).notNull()
+
+                t.uniqueKey([TransactionSyncerState.Columns.syncerId.name, TransactionSyncerState.Columns.lastBlockNumber.name], onConflict: .ignore)
+            }
+        }
+
+        return migrator
+    }
+
+}
+
+extension TransactionSyncerStateStorage {
+
+    func syncerState(syncerId: String) throws -> TransactionSyncerState? {
+        try dbPool.read { db in
+            try TransactionSyncerState.filter(TransactionSyncerState.Columns.syncerId == syncerId).fetchOne(db)
+        }
+    }
+
+    func save(syncerState: TransactionSyncerState) throws {
+        try dbPool.write { db in
+            try syncerState.save(db)
+        }
+    }
+
+}

--- a/EthereumKit/Classes/Models/Event.swift
+++ b/EthereumKit/Classes/Models/Event.swift
@@ -3,6 +3,7 @@ import BigInt
 
 public class Event: Record {
     public let hash: Data
+    public let blockNumber: Int
     public let contractAddress: Address
     public let from: Address
     public let to: Address
@@ -11,8 +12,9 @@ public class Event: Record {
     public let tokenSymbol: String
     public let tokenDecimal: Int
 
-    public init(hash: Data, contractAddress: Address, from: Address, to: Address, value: BigUInt, tokenName: String, tokenSymbol: String, tokenDecimal: Int) {
+    public init(hash: Data, blockNumber: Int, contractAddress: Address, from: Address, to: Address, value: BigUInt, tokenName: String, tokenSymbol: String, tokenDecimal: Int) {
         self.hash = hash
+        self.blockNumber = blockNumber
         self.contractAddress = contractAddress
         self.from = from
         self.to = to
@@ -30,6 +32,7 @@ public class Event: Record {
 
     enum Columns: String, ColumnExpression {
         case hash
+        case blockNumber
         case contractAddress
         case from
         case to
@@ -41,6 +44,7 @@ public class Event: Record {
 
     required public init(row: Row) {
         hash = row[Columns.hash]
+        blockNumber = row[Columns.blockNumber]
         contractAddress = Address(raw: row[Columns.contractAddress])
         from = Address(raw: row[Columns.from])
         to = Address(raw: row[Columns.to])
@@ -54,6 +58,7 @@ public class Event: Record {
 
     override public func encode(to container: inout PersistenceContainer) {
         container[Columns.hash] = hash
+        container[Columns.blockNumber] = blockNumber
         container[Columns.contractAddress] = contractAddress.raw
         container[Columns.from] = from.raw
         container[Columns.to] = to.raw

--- a/EthereumKit/Classes/Models/InternalTransaction.swift
+++ b/EthereumKit/Classes/Models/InternalTransaction.swift
@@ -3,13 +3,15 @@ import BigInt
 
 public class InternalTransaction: Record {
     public let hash: Data
+    public let blockNumber: Int
     public let from: Address
     public let to: Address
     public let value: BigUInt
     public let traceId: String
 
-    init(hash: Data, from: Address, to: Address, value: BigUInt, traceId: String) {
+    init(hash: Data, blockNumber: Int, from: Address, to: Address, value: BigUInt, traceId: String) {
         self.hash = hash
+        self.blockNumber = blockNumber
         self.from = from
         self.to = to
         self.value = value
@@ -24,6 +26,7 @@ public class InternalTransaction: Record {
 
     enum Columns: String, ColumnExpression, CaseIterable {
         case hash
+        case blockNumber
         case from
         case to
         case value
@@ -32,6 +35,7 @@ public class InternalTransaction: Record {
 
     required init(row: Row) {
         hash = row[Columns.hash]
+        blockNumber = row[Columns.blockNumber]
         from = Address(raw: row[Columns.from])
         to = Address(raw: row[Columns.to])
         value = row[Columns.value]
@@ -42,6 +46,7 @@ public class InternalTransaction: Record {
 
     override public func encode(to container: inout PersistenceContainer) {
         container[Columns.hash] = hash
+        container[Columns.blockNumber] = blockNumber
         container[Columns.from] = from.raw
         container[Columns.to] = to.raw
         container[Columns.value] = value

--- a/EthereumKit/Classes/Models/ProviderInternalTransaction.swift
+++ b/EthereumKit/Classes/Models/ProviderInternalTransaction.swift
@@ -12,6 +12,7 @@ public struct ProviderInternalTransaction {
     var internalTransaction: InternalTransaction {
         InternalTransaction(
                 hash: hash,
+                blockNumber: blockNumber,
                 from: from,
                 to: to,
                 value: value,

--- a/EthereumKit/Classes/Models/TransactionSyncerState.swift
+++ b/EthereumKit/Classes/Models/TransactionSyncerState.swift
@@ -1,0 +1,35 @@
+import GRDB
+
+class TransactionSyncerState: Record {
+    let syncerId: String
+    let lastBlockNumber: Int
+
+    init(syncerId: String, lastBlockNumber: Int) {
+        self.syncerId = syncerId
+        self.lastBlockNumber = lastBlockNumber
+
+        super.init()
+    }
+
+    public override class var databaseTableName: String {
+        "transactionSyncerStates"
+    }
+
+    enum Columns: String, ColumnExpression, CaseIterable {
+        case syncerId
+        case lastBlockNumber
+    }
+
+    required init(row: Row) {
+        syncerId = row[Columns.syncerId]
+        lastBlockNumber = row[Columns.lastBlockNumber]
+
+        super.init(row: row)
+    }
+
+    public override func encode(to container: inout PersistenceContainer) {
+        container[Columns.syncerId] = syncerId
+        container[Columns.lastBlockNumber] = lastBlockNumber
+    }
+
+}

--- a/EthereumKit/Classes/TransactionSyncers/InternalTransactionSyncer.swift
+++ b/EthereumKit/Classes/TransactionSyncers/InternalTransactionSyncer.swift
@@ -18,6 +18,7 @@ class InternalTransactionSyncer {
         let internalTransactions = transactions.map { tx in
             InternalTransaction(
                     hash: tx.hash,
+                    blockNumber: tx.blockNumber,
                     from: tx.from,
                     to: tx.to,
                     value: tx.value,
@@ -32,8 +33,10 @@ class InternalTransactionSyncer {
 
 extension InternalTransactionSyncer: ITransactionSyncer {
 
-    func transactionsSingle(lastBlockNumber: Int) -> Single<[Transaction]> {
-        provider.internalTransactionsSingle(startBlock: lastBlockNumber + 1)
+    func transactionsSingle() -> Single<[Transaction]> {
+        let lastBlockNumber = storage.lastInternalTransaction()?.blockNumber ?? 0
+
+        return provider.internalTransactionsSingle(startBlock: lastBlockNumber + 1)
                 .do(onSuccess: { [weak self] transactions in
                     self?.handle(transactions: transactions)
                 })

--- a/EthereumKit/Classes/TransactionSyncers/TransactionSyncManager.swift
+++ b/EthereumKit/Classes/TransactionSyncers/TransactionSyncManager.swift
@@ -76,9 +76,9 @@ extension TransactionSyncManager {
 
         state = .syncing(progress: nil)
 
-        let lastBlockNumber = transactionManager.lastTransaction()?.blockNumber ?? 0
-
-        Single.zip(syncers.map { $0.transactionsSingle(lastBlockNumber: lastBlockNumber) })
+        Single.zip(syncers.map { syncer in
+                    syncer.transactionsSingle().catchErrorJustReturn([])
+                })
                 .subscribeOn(ConcurrentDispatchQueueScheduler(qos: .utility))
                 .subscribe(
                         onSuccess: { [weak self] transactionsArray in


### PR DESCRIPTION
- use own last block numbers for syncers
- do not fail all syncers if one fails